### PR TITLE
#4 Fix encoding when decrypt text

### DIFF
--- a/lib/culqi/encryptor.rb
+++ b/lib/culqi/encryptor.rb
@@ -21,7 +21,8 @@ module Culqi
       decipher    = build_cipher(:decrypt)
       decipher.iv = decoded.slice!(0, 16)
 
-      decipher.update(decoded) + decipher.final
+      decrypt_text = decipher.update(decoded) + decipher.final
+      decrypt_text.force_encoding('utf-8')
     end
 
     private

--- a/lib/culqi/encryptor.rb
+++ b/lib/culqi/encryptor.rb
@@ -21,8 +21,8 @@ module Culqi
       decipher    = build_cipher(:decrypt)
       decipher.iv = decoded.slice!(0, 16)
 
-      decrypt_text = decipher.update(decoded) + decipher.final
-      decrypt_text.force_encoding('utf-8')
+      decrypted_text = decipher.update(decoded) + decipher.final
+      decrypted_text.force_encoding('utf-8')
     end
 
     private

--- a/test/encryptor_test.rb
+++ b/test/encryptor_test.rb
@@ -16,8 +16,9 @@ class EncryptorTest < Minitest::Test
     plaintext = 'test string'
     encrypted = encryptor.encrypt(plaintext)
 
-    decrypt_text = encryptor.decrypt(encrypted)
+    decrypted_text = encryptor.decrypt(encrypted)
 
-    assert_equal decrypt_text.encoding.name, 'UTF-8'
+    assert_equal decrypted_text.encoding.name, 'UTF-8'
+    assert_equal decrypted_text, 'test string'
   end
 end

--- a/test/encryptor_test.rb
+++ b/test/encryptor_test.rb
@@ -10,4 +10,14 @@ class EncryptorTest < Minitest::Test
 
     assert_equal plaintext, encryptor.decrypt(encrypted)
   end
+
+  def test_decrypt_encoding
+    encryptor = Culqi::Encryptor.new
+    plaintext = 'test string'
+    encrypted = encryptor.encrypt(plaintext)
+
+    decrypt_text = encryptor.decrypt(encrypted)
+
+    assert_equal decrypt_text.encoding.name, 'UTF-8'
+  end
 end


### PR DESCRIPTION
El encodificado de decrypt debe ser en UTF-8 de acuerdo a la documentación de Culqi

https://www.culqi.com/docs/#9-4-ejemplo-de-descifrado

resultado <- Es el valor de “descifrado” codificado en UTF8.
